### PR TITLE
Update selector for Netflix changes

### DIFF
--- a/Netflix-Pause-Removal.user.js
+++ b/Netflix-Pause-Removal.user.js
@@ -6,4 +6,4 @@
 // @description Automatically clicks "continue playing"
 // ==/UserScript==
 setInterval(function(){}, 9999); //Dummy SetInterval (Gets cleared during netflix's load events)
-setInterval(function(){try{document.getElementsByClassName("button continue-playing")[0].click()}catch(e){}}, 33);
+setInterval(function(){try{document.getElementsByClassName("interrupter-actions")[0].getElementsByClassName("nf-flat-button")[0].click()}catch(e){}}, 33);


### PR DESCRIPTION
Seems like Netflix has updated their player and the button selector isn't working anymore. I've changed it to first look for the "interrupter-actions" box that appears and then click the first button (since they don't have unique classes like "continue-playing" anymore.